### PR TITLE
Fix MSRV at 1.38.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
       # MSRV
-      rust: 1.32.0
+      rust: 1.38.0
 
 before_install:
   - set -e

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.32.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.38.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
gimli says:

> The minimum supported Rust version is 1.38.0.

which means that we cannot guarantee to compile on any older version than that.