### PR TITLE
Use thiserror instead of failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
       # MSRV
-      rust: 1.38.0
+      rust: 1.31.0
 
 before_install:
   - set -e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,5 @@ version = "0.4.0"
 
 [dependencies]
 byteorder = "1.3.0"
-failure = "0.1.5"
-failure_derive = "0.1.5"
+thiserror = "1.0.19"
 either = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is developed and maintained by the [Cortex-M team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.38.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.31.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::io::{self, ErrorKind, Read};
 
 use byteorder::{ByteOrder, LE};
 use either::Either;
-use failure_derive::Fail;
+use thiserror::Error;
 
 use crate::packet::{
     DataTraceAddress, DataTraceDataValue, DataTracePcValue, EventCounter, ExceptionTrace, Function,
@@ -156,17 +156,17 @@ where
 }
 
 /// ITM packet decoding errors
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// The packet starts with a reserved header byte
-    #[fail(display = "reserved header byte: {}", byte)]
+    #[error("reserved header byte: {byte}")]
     ReservedHeader {
         /// The header byte
         byte: u8,
     },
 
     /// The packet doesn't adhere to the (ARMv7-M) specification
-    #[fail(display = "malformed packet of length {} with header: {}", len, header)]
+    #[error("malformed packet of length {len} with header {header}")]
     MalformedPacket {
         /// The header of the malformed packet
         header: u8,


### PR DESCRIPTION
Failure is deprecated and by default pulls in a lot of dependencies, including ELF parsers.

As a side effect, we can now build on Rust 1.31.0 and up.

r? @adamgreig 